### PR TITLE
fix: rollback to qtrees.ai URL

### DIFF
--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -4,7 +4,7 @@
     "addition": "",
     "full": "TreeWatch"
   },
-  "url": "treewatch.ai",
+  "url": "qtrees.ai",
   "time": {
     "minShortened": "Min"
   },


### PR DESCRIPTION
There was one thing we had overlooked when doing the branding change. The URL in the top right corner of the home screen should continue leading to qtrees.ai because it is the project website.