### PR TITLE
feat(QTREES-365): tree view carousel

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import { Header } from '@components/Header'
 import { GetServerSideProps } from 'next'
 import { FC } from 'react'
-import { HomeSlider } from '@components/HomeSlider'
+import { HomeCarousel } from '@components/HomeCarousel'
 import { LegalLinks } from '@components/LegalLinks'
 import { GPSButton } from '@components/GPSButton'
 
@@ -18,7 +18,7 @@ export const Home: FC = () => {
     <>
       <div className="grid grid-cols-1 grid-rows-[auto,1fr,auto] h-full">
         <Header />
-        <HomeSlider />
+        <HomeCarousel />
         <div className="px-4 py-8 mx-auto max-w-md w-full">
           <GPSButton />
           <LegalLinks />

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -193,36 +193,42 @@ const TreePage: TreePageWithLayout = ({ treeData }) => {
         <div
           className={classNames(
             'bg-white',
-            'rounded-t-2xl shadow-[0_-12px_24px_-16px_rgba(0,0,0,0.3)]',
             'row-start-2 row-span-1',
             'grid grid-cols-1 grid-rows-auto',
-            'overflow-hidden',
             'motion-safe:animate-slide-up'
           )}
         >
-          <Carousel dotsClass="slick-dots w-2/6 md:w-1/4 mx-auto">
-            {!nowcastError && (
-              <SuctionTensionViz
-                depth30Level={
-                  nowcastData && nowcastData[0].value
-                    ? mapSuctionTensionToLevel(nowcastData[0].value)
-                    : undefined
-                }
-                depth60Level={
-                  nowcastData && nowcastData[1].value
-                    ? mapSuctionTensionToLevel(nowcastData[1].value)
-                    : undefined
-                }
-                depth90Level={
-                  nowcastData && nowcastData[2].value
-                    ? mapSuctionTensionToLevel(nowcastData[2].value)
-                    : undefined
-                }
-                averageLevel={avgLevel}
-              />
+          <div
+            className={classNames(
+              'w-full sticky top-0',
+              'overflow-hidden rounded-t-2xl',
+              'shadow-[0_-12px_24px_-16px_rgba(0,0,0,0.3)]'
             )}
-            <div className="bg-scale-4 h-full">Bar chart</div>
-          </Carousel>
+          >
+            <Carousel dotsClass="slick-dots w-2/6 md:w-1/4 mx-auto">
+              {!nowcastError && (
+                <SuctionTensionViz
+                  depth30Level={
+                    nowcastData && nowcastData[0].value
+                      ? mapSuctionTensionToLevel(nowcastData[0].value)
+                      : undefined
+                  }
+                  depth60Level={
+                    nowcastData && nowcastData[1].value
+                      ? mapSuctionTensionToLevel(nowcastData[1].value)
+                      : undefined
+                  }
+                  depth90Level={
+                    nowcastData && nowcastData[2].value
+                      ? mapSuctionTensionToLevel(nowcastData[2].value)
+                      : undefined
+                  }
+                  averageLevel={avgLevel}
+                />
+              )}
+              <div className="bg-scale-4 h-full">Bar chart</div>
+            </Carousel>
+          </div>
           <TreeInfoHeader
             species={treeData.art_dtsch || 'Unbekannte Art'}
             age={treeData.standalter}

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -11,6 +11,7 @@ import { SuctionTensionViz } from '@components/SuctionTensionViz'
 import { useRouter } from 'next/router'
 import { Cross as CrossIcon } from '@components/Icons'
 import { useHasScrolledPastThreshold } from '@lib/hooks/useHasScrolledPastThreshold'
+import { Carousel } from '@components/Carousel'
 
 interface TreePageComponentPropType {
   treeData: TreeDataType
@@ -133,29 +134,34 @@ const TreePage: TreePageWithLayout = ({ treeData }) => {
             'bg-white',
             'rounded-t-2xl shadow-[0_-12px_24px_-16px_rgba(0,0,0,0.3)]',
             'row-start-2 row-span-1',
+            'grid grid-cols-1 grid-rows-auto',
+            'overflow-hidden',
             'motion-safe:animate-slide-up'
           )}
         >
-          {!nowcastError && (
-            <SuctionTensionViz
-              depth30Level={
-                nowcastData && nowcastData[0].value
-                  ? mapSuctionTensionToLevel(nowcastData[0].value)
-                  : undefined
-              }
-              depth60Level={
-                nowcastData && nowcastData[1].value
-                  ? mapSuctionTensionToLevel(nowcastData[1].value)
-                  : undefined
-              }
-              depth90Level={
-                nowcastData && nowcastData[2].value
-                  ? mapSuctionTensionToLevel(nowcastData[2].value)
-                  : undefined
-              }
-              averageLevel={avgLevel}
-            />
-          )}
+          <Carousel>
+            {!nowcastError && (
+              <SuctionTensionViz
+                depth30Level={
+                  nowcastData && nowcastData[0].value
+                    ? mapSuctionTensionToLevel(nowcastData[0].value)
+                    : undefined
+                }
+                depth60Level={
+                  nowcastData && nowcastData[1].value
+                    ? mapSuctionTensionToLevel(nowcastData[1].value)
+                    : undefined
+                }
+                depth90Level={
+                  nowcastData && nowcastData[2].value
+                    ? mapSuctionTensionToLevel(nowcastData[2].value)
+                    : undefined
+                }
+                averageLevel={avgLevel}
+              />
+            )}
+            <div className="bg-scale-4 h-full">Bar chart</div>
+          </Carousel>
           <TreeInfoHeader
             species={treeData.art_dtsch || 'Unbekannte Art'}
             age={treeData.standalter}

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -139,7 +139,7 @@ const TreePage: TreePageWithLayout = ({ treeData }) => {
             'motion-safe:animate-slide-up'
           )}
         >
-          <Carousel>
+          <Carousel dotsClass="slick-dots w-2/6 md:w-1/4 mx-auto">
             {!nowcastError && (
               <SuctionTensionViz
                 depth30Level={

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -3,7 +3,10 @@ import { FC } from 'react'
 import Slider from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 
-export const Carousel: FC = ({ children }) => {
+export const Carousel: FC<{ innerSliderClass?: string }> = ({
+  innerSliderClass,
+  children,
+}) => {
   return (
     <Slider
       arrows={false}
@@ -28,6 +31,7 @@ export const Carousel: FC = ({ children }) => {
           ></span>
         </button>
       )}
+      className={classNames(innerSliderClass, 'bg-white')}
     >
       {children}
     </Slider>

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -3,8 +3,8 @@ import { FC } from 'react'
 import Slider from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 
-export const Carousel: FC<{ innerSliderClass?: string }> = ({
-  innerSliderClass,
+export const Carousel: FC<{ wrapperClass?: string }> = ({
+  wrapperClass,
   children,
 }) => {
   return (
@@ -31,7 +31,7 @@ export const Carousel: FC<{ innerSliderClass?: string }> = ({
           ></span>
         </button>
       )}
-      className={classNames(innerSliderClass, 'bg-white')}
+      className={classNames(wrapperClass, 'bg-white')}
     >
       {children}
     </Slider>

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,0 +1,35 @@
+import classNames from 'classnames'
+import { FC } from 'react'
+import Slider from 'react-slick'
+import 'slick-carousel/slick/slick.css'
+
+export const Carousel: FC = ({ children }) => {
+  return (
+    <Slider
+      arrows={false}
+      infinite={false}
+      dots
+      customPaging={(i) => (
+        <button
+          aria-label={`Slide ${i + 1}`}
+          className={classNames(
+            'group',
+            'w-full h-1 py-3',
+            'transition-colors focus:outline-none focus:!ring-0',
+            'flex place-content-center place-items-center'
+          )}
+        >
+          <span
+            className={classNames(
+              'w-full h-1',
+              'rounded-full bg-gray-300',
+              'group-focus:ring-offset-2 group-focus:ring-offset-white group-focus:ring-2 group-focus:ring-gray-900'
+            )}
+          ></span>
+        </button>
+      )}
+    >
+      {children}
+    </Slider>
+  )
+}

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -3,8 +3,9 @@ import { FC } from 'react'
 import Slider from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 
-export const Carousel: FC<{ wrapperClass?: string }> = ({
+export const Carousel: FC<{ wrapperClass?: string; dotsClass?: string }> = ({
   wrapperClass,
+  dotsClass = 'slick-dots',
   children,
 }) => {
   return (
@@ -12,6 +13,7 @@ export const Carousel: FC<{ wrapperClass?: string }> = ({
       arrows={false}
       infinite={false}
       dots
+      dotsClass={dotsClass}
       customPaging={(i) => (
         <button
           aria-label={`Slide ${i + 1}`}

--- a/src/components/HomeCarousel/index.tsx
+++ b/src/components/HomeCarousel/index.tsx
@@ -5,14 +5,17 @@ import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { FC } from 'react'
 
-interface HomeSlidePropType {
+interface HomeCarouselPropType {
   img: {
     url: string
     alt: string
   }
 }
 
-const HomeSlide: FC<HomeSlidePropType> = ({ img: { url, alt }, children }) => (
+const HomeSlide: FC<HomeCarouselPropType> = ({
+  img: { url, alt },
+  children,
+}) => (
   <div className="px-4">
     <div className="border border-gray-200 rounded-lg h-full grid grid-rows-[auto,1fr] grid-cols-1">
       <img src={url} alt={alt} className="w-full float-left rounded-t-lg" />
@@ -36,7 +39,7 @@ const Pill: FC<{ className?: string }> = ({ className = '', children }) => (
   </span>
 )
 
-export const HomeSlider: FC = () => {
+export const HomeCarousel: FC = () => {
   const { t } = useTranslation('common')
   const formattingComponents = {
     bold: <strong />,

--- a/src/components/HomeSlider/index.tsx
+++ b/src/components/HomeSlider/index.tsx
@@ -1,10 +1,9 @@
+import { Carousel } from '@components/Carousel'
 import { SuctionTensionScale } from '@components/SuctionTensionScale'
 import classNames from 'classnames'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { FC } from 'react'
-import Slider from 'react-slick'
-import 'slick-carousel/slick/slick.css'
 
 interface HomeSlidePropType {
   img: {
@@ -47,30 +46,7 @@ export const HomeSlider: FC = () => {
     '5': <Pill className="bg-scale-5 border-scale-5-dark">5</Pill>,
   }
   return (
-    <Slider
-      arrows={false}
-      infinite={false}
-      dots
-      customPaging={(i) => (
-        <button
-          aria-label={`Slide ${i + 1}`}
-          className={classNames(
-            'group',
-            'w-full h-1 py-3',
-            'transition-colors focus:outline-none focus:!ring-0',
-            'flex place-content-center place-items-center'
-          )}
-        >
-          <span
-            className={classNames(
-              'w-full h-1',
-              'rounded-full bg-gray-300',
-              'group-focus:ring-offset-2 group-focus:ring-offset-white group-focus:ring-2 group-focus:ring-gray-900'
-            )}
-          ></span>
-        </button>
-      )}
-    >
+    <Carousel>
       <HomeSlide
         img={{
           url: '/images/home-slider/1.svg',
@@ -148,6 +124,6 @@ export const HomeSlider: FC = () => {
           components={formattingComponents}
         />
       </HomeSlide>
-    </Slider>
+    </Carousel>
   )
 }

--- a/src/components/SuctionTensionViz/SoilLayer.tsx
+++ b/src/components/SuctionTensionViz/SoilLayer.tsx
@@ -15,7 +15,7 @@ export const SoilLayer: FC<{
     className={classNames(
       'h-20',
       'pl-6',
-      'border-t first-of-type:rounded-t-xl',
+      'border-t first-of-type:border-t-0',
       'flex items-center',
       'transition-colors'
     )}

--- a/src/components/SuctionTensionViz/index.tsx
+++ b/src/components/SuctionTensionViz/index.tsx
@@ -20,7 +20,7 @@ export const SuctionTensionViz: FC<SuctionTensionVizType> = ({
   averageLevel,
 }) => {
   return (
-    <div className="w-full sticky z-0 top-0 overflow-hidden rounded-t-lg">
+    <div className="relative overflow-hidden">
       <SoilLayer depth={30} level={depth30Level} />
       <SoilLayer depth={60} level={depth60Level} />
       <SoilLayer depth={90} level={depth90Level} />

--- a/src/style/global.css
+++ b/src/style/global.css
@@ -111,7 +111,7 @@
 }
 
 .slick-dots {
-	@apply px-4 justify-evenly gap-4;
+	@apply px-4 py-2 justify-evenly gap-4;
 	display: flex !important;
 }
 
@@ -128,7 +128,7 @@
 }
 
 .slick-dots > li {
-	@apply w-full h-1;
+	@apply w-full h-1 flex items-center;
 }
 
 .slick-dots > li.slick-active > button > span {


### PR DESCRIPTION
This PR adds a carousel element to the tree page. One slide contains the roots visualization and the other is a placeholder for the forecast barchart.

Note that even though `react-slick` calls the UI a `Slider`, I have changed this to `Carousel` for us, because it's less ambiguous than `Slider`.

---

- [x] basic slider/carousel
- [x] customize dots style
- [x] make viz area sticky again
- [x] hide dots when scrolled down