### PR TITLE
feat(QTREES-366): create forecast barchart component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@next/mdx": "12.2.0",
         "@tailwindcss/typography": "0.5.4",
         "classnames": "2.3.1",
+        "date-fns": "2.29.1",
         "maplibre-gl": "2.1.9",
         "next-translate": "1.5.0",
         "react": "17.0.2",
@@ -10756,6 +10757,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -35815,6 +35828,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@next/mdx": "12.2.0",
     "@tailwindcss/typography": "0.5.4",
     "classnames": "2.3.1",
+    "date-fns": "2.29.1",
     "maplibre-gl": "2.1.9",
     "next-translate": "1.5.0",
     "react": "17.0.2",

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -56,7 +56,7 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   }
 }
 
-const getRingClassesByLevel = (
+export const getRingClassesByLevel = (
   level: number | undefined
 ): {
   bg: string

--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -14,6 +14,7 @@ import { useHasScrolledPastThreshold } from '@lib/hooks/useHasScrolledPastThresh
 import { NowcastDataType } from '@lib/requests/getNowcastData'
 import { Tabs } from '@components/Tabs'
 import useTranslation from 'next-translate/useTranslation'
+import { getScaleClassesByLevel } from '@lib/utils/getScaleClassesByLevel'
 
 interface TreePageComponentPropType {
   treeData: TreeDataType
@@ -53,28 +54,6 @@ export const getServerSideProps: GetServerSideProps = async ({ params }) => {
     return {
       notFound: true,
     }
-  }
-}
-
-export const getRingClassesByLevel = (
-  level: number | undefined
-): {
-  bg: string
-  border: string
-} => {
-  switch (level) {
-    case 1:
-      return { bg: 'bg-scale-1', border: 'border-scale-1-dark' }
-    case 2:
-      return { bg: 'bg-scale-2', border: 'border-scale-2-dark' }
-    case 3:
-      return { bg: 'bg-scale-3', border: 'border-scale-3-dark' }
-    case 4:
-      return { bg: 'bg-scale-4', border: 'border-scale-4-dark' }
-    case 5:
-      return { bg: 'bg-scale-5', border: 'border-scale-5-dark' }
-    default:
-      return { bg: 'bg-gray-300', border: 'border-gray-400' }
   }
 }
 
@@ -152,7 +131,7 @@ const TreePage: TreePageWithLayout = ({ treeData }) => {
     nowcastData && nowcastData[3].value
       ? mapSuctionTensionToLevel(nowcastData[3].value)
       : undefined
-  const circleColorClasses = getRingClassesByLevel(avgLevel)
+  const circleColorClasses = getScaleClassesByLevel(avgLevel)
 
   return (
     <div id="inidividual-tree-container">

--- a/src/components/ForecastBarChart/BarChart.stories.tsx
+++ b/src/components/ForecastBarChart/BarChart.stories.tsx
@@ -1,4 +1,6 @@
+import { SuctionTensionLevel } from '@lib/utils/mapSuctionTensionToLevel'
 import { Story, Meta } from '@storybook/react'
+import { addDays } from 'date-fns'
 
 import { ForecastBarChart, ForecastBarChartPropType } from '.'
 
@@ -13,39 +15,21 @@ const Template: Story<ForecastBarChartPropType> = (props) => (
   </div>
 )
 
+const getRandomInt = (min: number, max: number): number => {
+  min = Math.ceil(min)
+  max = Math.floor(max)
+  return Math.floor(Math.random() * (max - min + 1)) + min
+}
+
 export const Default = Template.bind({})
 
 Default.args = {
-  data: [
-    {
-      date: '2022-08-11',
-      suctionTensionLevel: 5,
-    },
-    {
-      date: '2022-08-12',
-      suctionTensionLevel: 3,
-    },
-    {
-      date: '2022-08-13',
-      suctionTensionLevel: 4,
-    },
-    {
-      date: '2022-08-14',
-      suctionTensionLevel: 3,
-    },
-    {
-      date: '2022-08-15',
-      suctionTensionLevel: 2,
-    },
-    {
-      date: '2022-08-16',
-      suctionTensionLevel: 3,
-    },
-    {
-      date: '2022-08-17',
-      suctionTensionLevel: 1,
-    },
-  ],
+  data: Array.from(Array(14)).map((_, i: number) => {
+    return {
+      date: addDays(Date.now(), i),
+      suctionTensionLevel: getRandomInt(1, 5) as SuctionTensionLevel,
+    }
+  }),
 }
 
 export const MissingData = Template.bind({})

--- a/src/components/ForecastBarChart/BarChart.stories.tsx
+++ b/src/components/ForecastBarChart/BarChart.stories.tsx
@@ -26,7 +26,7 @@ Default.args = {
       suctionTensionLevel: 3,
     },
     {
-      date: '2022-08-13-kjkjkjkj',
+      date: '2022-08-13',
       suctionTensionLevel: 4,
     },
     {

--- a/src/components/ForecastBarChart/BarChart.stories.tsx
+++ b/src/components/ForecastBarChart/BarChart.stories.tsx
@@ -1,0 +1,49 @@
+import { Story, Meta } from '@storybook/react'
+
+import { ForecastBarChart, ForecastBarChartPropType } from '.'
+
+export default {
+  title: 'UI Elements/ForecastBarChart',
+  component: ForecastBarChart,
+} as Meta
+
+const Template: Story<ForecastBarChartPropType> = (props) => (
+  <div className="w-full h-72">
+    <ForecastBarChart {...props} />
+  </div>
+)
+
+export const Default = Template.bind({})
+
+Default.args = {
+  data: [
+    {
+      date: '2022-08-11',
+      suctionTensionLevel: 5,
+    },
+    {
+      date: '2022-08-12',
+      suctionTensionLevel: 3,
+    },
+    {
+      date: '2022-08-13-kjkjkjkj',
+      suctionTensionLevel: 4,
+    },
+    {
+      date: '2022-08-14',
+      suctionTensionLevel: 3,
+    },
+    {
+      date: '2022-08-15',
+      suctionTensionLevel: 2,
+    },
+    {
+      date: '2022-08-16',
+      suctionTensionLevel: 3,
+    },
+    {
+      date: '2022-08-17',
+      suctionTensionLevel: 1,
+    },
+  ],
+}

--- a/src/components/ForecastBarChart/BarChart.stories.tsx
+++ b/src/components/ForecastBarChart/BarChart.stories.tsx
@@ -8,7 +8,7 @@ export default {
 } as Meta
 
 const Template: Story<ForecastBarChartPropType> = (props) => (
-  <div className="w-full h-72">
+  <div className="w-full h-72 border border-gray-200">
     <ForecastBarChart {...props} />
   </div>
 )

--- a/src/components/ForecastBarChart/BarChart.stories.tsx
+++ b/src/components/ForecastBarChart/BarChart.stories.tsx
@@ -47,3 +47,7 @@ Default.args = {
     },
   ],
 }
+
+export const MissingData = Template.bind({})
+
+MissingData.args = {}

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -9,7 +9,7 @@ interface DataItem {
 }
 
 export interface ForecastBarChartPropType {
-  data: DataItem[]
+  data?: DataItem[]
 }
 
 const SUCTION_TENSION_LEVELS: SuctionTensionLevel[] = [1, 2, 3, 4, 5]
@@ -24,7 +24,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
   const MAX_Y_VALUE = 5 // Max suction tension
 
   const GRID_AXES_CLASSES = {
-    gridTemplateColumns: `repeat(${data.length}, minmax(0, 1fr))`,
+    gridTemplateColumns: `repeat(${data?.length || 1}, minmax(0, 1fr))`,
     gridTemplateRows: `repeat(${MAX_Y_VALUE}, minmax(0, 1fr))`,
   }
 
@@ -61,33 +61,38 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
           {SUCTION_TENSION_LEVELS.reverse().map((level) => {
             return (
               <div
-                key={`suction-tension-axis-level-${data.length}`}
+                key={`suction-tension-axis-level-${level}`}
                 className="w-[calc(100%+16px)] -translate-x-[8px] border-t border-gray-200"
-                style={{ gridColumn: `span ${data.length}`, gridRow: level }}
+                style={{
+                  gridColumn: `span ${data?.length || 1}`,
+                  gridRow: level,
+                }}
               ></div>
             )
           })}
         </div>
-        <div className={GRID_BASE_CLASSES} style={{ ...GRID_AXES_CLASSES }}>
-          {data.map((dataItem) => {
-            return (
-              <div
-                key={dataItem.date}
-                className={classNames(
-                  'relative flex justify-center',
-                  'overflow-hidden',
-                  'row-start-[-1]',
-                  getRingClassesByLevel(dataItem.suctionTensionLevel).bg
-                )}
-                style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
-              >
-                {/* <span className="absolute bottom-0 w-full -rotate-90 -translate-y-full whitespace-nowrap">
+        {data && (
+          <div className={GRID_BASE_CLASSES} style={{ ...GRID_AXES_CLASSES }}>
+            {data.map((dataItem) => {
+              return (
+                <div
+                  key={dataItem.date}
+                  className={classNames(
+                    'relative flex justify-center',
+                    'overflow-hidden',
+                    'row-start-[-1]',
+                    getRingClassesByLevel(dataItem.suctionTensionLevel).bg
+                  )}
+                  style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
+                >
+                  {/* <span className="absolute bottom-0 w-full -rotate-90 -translate-y-full whitespace-nowrap">
               {dataItem.xValue}
             </span> */}
-              </div>
-            )
-          })}
-        </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -6,7 +6,7 @@ import { FC } from 'react'
 
 interface DataItem {
   suctionTensionLevel: SuctionTensionLevel
-  date: string
+  date: Date
 }
 
 export interface ForecastBarChartPropType {
@@ -24,7 +24,7 @@ const VIZ_GRID_BASE_CLASSES = classNames(
 )
 
 const getDateLabel = (date: Date): string => {
-  return `${format(new Date(date), 'dd.MM.')}${isToday(date) ? ' (Heute)' : ''}`
+  return `${format(date, 'dd.MM.')}${isToday(date) ? ' (Heute)' : ''}`
 }
 
 export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
@@ -90,7 +90,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
             {data.map((dataItem) => {
               return (
                 <div
-                  key={dataItem.date}
+                  key={dataItem.date.toISOString()}
                   className={classNames(
                     'relative flex justify-center items-end',
                     'overflow-visible',
@@ -106,7 +106,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                       'text-gray-900 text-opacity-50 font-semibold whitespace-nowrap'
                     )}
                   >
-                    {getDateLabel(new Date(dataItem.date))}
+                    {getDateLabel(dataItem.date)}
                   </span>
                 </div>
               )

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -1,5 +1,6 @@
 import { SuctionTensionLevel } from '@lib/utils/mapSuctionTensionToLevel'
 import classNames from 'classnames'
+import { format } from 'date-fns'
 import { getRingClassesByLevel } from 'pages/trees/[id]'
 import { FC } from 'react'
 
@@ -78,16 +79,16 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                 <div
                   key={dataItem.date}
                   className={classNames(
-                    'relative flex justify-center',
+                    'relative flex justify-center items-end',
                     'overflow-hidden',
                     'row-start-[-1]',
                     getRingClassesByLevel(dataItem.suctionTensionLevel).bg
                   )}
                   style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
                 >
-                  {/* <span className="absolute bottom-0 w-full -rotate-90 -translate-y-full whitespace-nowrap">
-              {dataItem.xValue}
-            </span> */}
+                  <span className="pl-0 absolute bottom-0 text-gray-900 text-opacity-50 font-semibold -rotate-90 -translate-y-4 origin-center whitespace-nowrap">
+                    {format(new Date(dataItem.date), 'dd.MM.')}
+                  </span>
                 </div>
               )
             })}

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -1,7 +1,7 @@
 import { getScaleClassesByLevel } from '@lib/utils/getScaleClassesByLevel'
 import { SuctionTensionLevel } from '@lib/utils/mapSuctionTensionToLevel'
 import classNames from 'classnames'
-import { format } from 'date-fns'
+import { format, isToday } from 'date-fns'
 import { FC } from 'react'
 
 interface DataItem {
@@ -22,6 +22,10 @@ const VIZ_GRID_BASE_CLASSES = classNames(
   'w-full h-full px-2',
   'grid gap-x-[2px] gap-y-0'
 )
+
+const getDateLabel = (date: Date): string => {
+  return `${format(new Date(date), 'dd.MM.')}${isToday(date) ? ' (Heute)' : ''}`
+}
 
 export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
   const VIZ_GRID_AXES_CLASSES = {
@@ -102,7 +106,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                       'text-gray-900 text-opacity-50 font-semibold whitespace-nowrap'
                     )}
                   >
-                    {format(new Date(dataItem.date), 'dd.MM.')}
+                    {getDateLabel(new Date(dataItem.date))}
                   </span>
                 </div>
               )

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -15,16 +15,16 @@ export interface ForecastBarChartPropType {
 
 const SUCTION_TENSION_LEVELS: SuctionTensionLevel[] = [1, 2, 3, 4, 5]
 
-const GRID_BASE_CLASSES = classNames(
+const MAX_Y_VALUE = 5 // Max suction tension
+
+const VIZ_GRID_BASE_CLASSES = classNames(
   'absolute top-0 left-0',
   'w-full h-full px-2',
   'grid gap-x-[2px] gap-y-0'
 )
 
 export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
-  const MAX_Y_VALUE = 5 // Max suction tension
-
-  const GRID_AXES_CLASSES = {
+  const VIZ_GRID_AXES_CLASSES = {
     gridTemplateColumns: `repeat(${data?.length || 1}, minmax(0, 1fr))`,
     gridTemplateRows: `repeat(${MAX_Y_VALUE}, minmax(0, 1fr))`,
   }
@@ -58,12 +58,18 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
         })}
       </div>
       <div className={classNames('relative w-full h-full overflow-x-visible')}>
-        <div className={GRID_BASE_CLASSES} style={{ ...GRID_AXES_CLASSES }}>
+        <div
+          className={VIZ_GRID_BASE_CLASSES}
+          style={{ ...VIZ_GRID_AXES_CLASSES }}
+        >
           {SUCTION_TENSION_LEVELS.reverse().map((level) => {
             return (
               <div
                 key={`suction-tension-axis-level-${level}`}
-                className="w-[calc(100%+16px)] -translate-x-[8px] border-t border-gray-200"
+                className={classNames(
+                  'w-[calc(100%+16px)] -translate-x-[8px]',
+                  'border-t border-gray-200'
+                )}
                 style={{
                   gridColumn: `span ${data?.length || 1}`,
                   gridRow: level,
@@ -73,7 +79,10 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
           })}
         </div>
         {data && (
-          <div className={GRID_BASE_CLASSES} style={{ ...GRID_AXES_CLASSES }}>
+          <div
+            className={VIZ_GRID_BASE_CLASSES}
+            style={{ ...VIZ_GRID_AXES_CLASSES }}
+          >
             {data.map((dataItem) => {
               return (
                 <div
@@ -86,7 +95,13 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                   )}
                   style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
                 >
-                  <span className="pl-0 absolute bottom-0 text-gray-900 text-opacity-50 font-semibold -rotate-90 -translate-y-4 origin-center whitespace-nowrap">
+                  <span
+                    className={classNames(
+                      'absolute bottom-0',
+                      '-rotate-90 -translate-y-4 origin-center',
+                      'text-gray-900 text-opacity-50 font-semibold whitespace-nowrap'
+                    )}
+                  >
                     {format(new Date(dataItem.date), 'dd.MM.')}
                   </span>
                 </div>

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -93,7 +93,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                   key={dataItem.date}
                   className={classNames(
                     'relative flex justify-center items-end',
-                    'overflow-hidden',
+                    'overflow-visible',
                     'row-start-[-1]',
                     getScaleClassesByLevel(dataItem.suctionTensionLevel).bg
                   )}
@@ -101,7 +101,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                 >
                   <span
                     className={classNames(
-                      'absolute bottom-0',
+                      'absolute bottom-0 w-[45px]',
                       '-rotate-90 -translate-y-4 origin-center',
                       'text-gray-900 text-opacity-50 font-semibold whitespace-nowrap'
                     )}

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -1,7 +1,7 @@
+import { getScaleClassesByLevel } from '@lib/utils/getScaleClassesByLevel'
 import { SuctionTensionLevel } from '@lib/utils/mapSuctionTensionToLevel'
 import classNames from 'classnames'
 import { format } from 'date-fns'
-import { getRingClassesByLevel } from 'pages/trees/[id]'
 import { FC } from 'react'
 
 interface DataItem {
@@ -82,7 +82,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                     'relative flex justify-center items-end',
                     'overflow-hidden',
                     'row-start-[-1]',
-                    getRingClassesByLevel(dataItem.suctionTensionLevel).bg
+                    getScaleClassesByLevel(dataItem.suctionTensionLevel).bg
                   )}
                   style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
                 >

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -12,35 +12,83 @@ export interface ForecastBarChartPropType {
   data: DataItem[]
 }
 
+const SUCTION_TENSION_LEVELS: SuctionTensionLevel[] = [1, 2, 3, 4, 5]
+
+const GRID_BASE_CLASSES = classNames(
+  'absolute top-0 left-0',
+  'w-full h-full px-2',
+  'grid gap-x-[2px] gap-y-0'
+)
+
 export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
   const MAX_Y_VALUE = 5 // Max suction tension
 
+  const GRID_AXES_CLASSES = {
+    gridTemplateColumns: `repeat(${data.length}, minmax(0, 1fr))`,
+    gridTemplateRows: `repeat(${MAX_Y_VALUE}, minmax(0, 1fr))`,
+  }
+
   return (
     <div
-      className="w-full h-full grid gap-[2px]"
-      style={{
-        gridTemplateColumns: `repeat(${data.length}, minmax(0, 1fr))`,
-        gridTemplateRows: `repeat(${MAX_Y_VALUE}, minmax(0, 1fr))`,
-      }}
+      className={classNames(
+        'w-full h-full',
+        'pt-3',
+        'bg-white',
+        'grid grid-cols-[auto,1fr] gap-0'
+      )}
     >
-      {data.map((dataItem) => {
-        return (
-          <div
-            key={dataItem.date}
-            className={classNames(
-              'relative flex justify-center',
-              'overflow-hidden',
-              'row-start-[-1]',
-              getRingClassesByLevel(dataItem.suctionTensionLevel).bg
-            )}
-            style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
-          >
-            {/* <span className="absolute bottom-0 w-full -rotate-90 -translate-y-full whitespace-nowrap">
+      <div
+        className="w-full grid grid-cols-1 gap-0 justify-center"
+        style={{ gridTemplateRows: `repeat(${MAX_Y_VALUE}, minmax(0, 1fr))` }}
+      >
+        {SUCTION_TENSION_LEVELS.reverse().map((level) => {
+          return (
+            <span
+              key={`suction-tension-level-${level}`}
+              className={classNames(
+                ' px-2',
+                '-translate-y-3',
+                'text-gray-900 text-opacity-50 font-semibold'
+              )}
+            >
+              {level}
+            </span>
+          )
+        })}
+      </div>
+      <div className={classNames('relative w-full h-full overflow-x-visible')}>
+        <div className={GRID_BASE_CLASSES} style={{ ...GRID_AXES_CLASSES }}>
+          {SUCTION_TENSION_LEVELS.reverse().map((level) => {
+            return (
+              <div
+                key={`suction-tension-axis-level-${data.length}`}
+                className="w-[calc(100%+16px)] -translate-x-[8px] border-t border-gray-200"
+                style={{ gridColumn: `span ${data.length}`, gridRow: level }}
+              ></div>
+            )
+          })}
+        </div>
+        <div className={GRID_BASE_CLASSES} style={{ ...GRID_AXES_CLASSES }}>
+          {data.map((dataItem) => {
+            return (
+              <div
+                key={dataItem.date}
+                className={classNames(
+                  'relative flex justify-center',
+                  'overflow-hidden',
+                  'row-start-[-1]',
+                  getRingClassesByLevel(dataItem.suctionTensionLevel).bg
+                )}
+                style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
+              >
+                {/* <span className="absolute bottom-0 w-full -rotate-90 -translate-y-full whitespace-nowrap">
               {dataItem.xValue}
             </span> */}
-          </div>
-        )
-      })}
+              </div>
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -103,7 +103,7 @@ export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
                     className={classNames(
                       'absolute bottom-0 w-[45px]',
                       '-rotate-90 -translate-y-4 origin-center',
-                      'text-gray-900 text-opacity-50 font-semibold whitespace-nowrap'
+                      'text-gray-900 text-opacity-50 font-semibold text-sm md:text-base whitespace-nowrap'
                     )}
                   >
                     {getDateLabel(dataItem.date)}

--- a/src/components/ForecastBarChart/index.tsx
+++ b/src/components/ForecastBarChart/index.tsx
@@ -1,0 +1,46 @@
+import { SuctionTensionLevel } from '@lib/utils/mapSuctionTensionToLevel'
+import classNames from 'classnames'
+import { getRingClassesByLevel } from 'pages/trees/[id]'
+import { FC } from 'react'
+
+interface DataItem {
+  suctionTensionLevel: SuctionTensionLevel
+  date: string
+}
+
+export interface ForecastBarChartPropType {
+  data: DataItem[]
+}
+
+export const ForecastBarChart: FC<ForecastBarChartPropType> = ({ data }) => {
+  const MAX_Y_VALUE = 5 // Max suction tension
+
+  return (
+    <div
+      className="w-full h-full grid gap-[2px]"
+      style={{
+        gridTemplateColumns: `repeat(${data.length}, minmax(0, 1fr))`,
+        gridTemplateRows: `repeat(${MAX_Y_VALUE}, minmax(0, 1fr))`,
+      }}
+    >
+      {data.map((dataItem) => {
+        return (
+          <div
+            key={dataItem.date}
+            className={classNames(
+              'relative flex justify-center',
+              'overflow-hidden',
+              'row-start-[-1]',
+              getRingClassesByLevel(dataItem.suctionTensionLevel).bg
+            )}
+            style={{ gridRowEnd: -(dataItem.suctionTensionLevel + 1) }}
+          >
+            {/* <span className="absolute bottom-0 w-full -rotate-90 -translate-y-full whitespace-nowrap">
+              {dataItem.xValue}
+            </span> */}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/lib/utils/getScaleClassesByLevel/index.ts
+++ b/src/lib/utils/getScaleClassesByLevel/index.ts
@@ -1,0 +1,21 @@
+export const getScaleClassesByLevel = (
+  level: number | undefined
+): {
+  bg: string
+  border: string
+} => {
+  switch (level) {
+    case 1:
+      return { bg: 'bg-scale-1', border: 'border-scale-1-dark' }
+    case 2:
+      return { bg: 'bg-scale-2', border: 'border-scale-2-dark' }
+    case 3:
+      return { bg: 'bg-scale-3', border: 'border-scale-3-dark' }
+    case 4:
+      return { bg: 'bg-scale-4', border: 'border-scale-4-dark' }
+    case 5:
+      return { bg: 'bg-scale-5', border: 'border-scale-5-dark' }
+    default:
+      return { bg: 'bg-gray-300', border: 'border-gray-400' }
+  }
+}


### PR DESCRIPTION
This PR creates the component for the forecast barchart via CSS grids (not implemented in page yet)

---

- [x] basic component (bars)
- [x] label, axes, etc.
- [x] value label within bars
- [x] extract suction tension to classes util
- [x] show (Heute) if today
- [x] refactor?