### PR TITLE
fix(QTREES-350): Broken tree url reloads

### DIFF
--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -16,6 +16,7 @@ import { NowcastDataType } from '@lib/requests/getNowcastData'
 import { Tabs } from '@components/Tabs'
 import useTranslation from 'next-translate/useTranslation'
 import { getScaleClassesByLevel } from '@lib/utils/getScaleClassesByLevel'
+import { treeUrlSlugToId } from '@lib/utils/urlUtil'
 
 interface TreePageComponentPropType {
   treeData: TreeDataType
@@ -33,7 +34,8 @@ type TreePageWithLayout = NextPage<TreePageComponentPropType> & {
 // eslint-disable-next-line @typescript-eslint/require-await
 export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   try {
-    const treeId = typeof params?.id === 'string' ? params.id : null
+    const treeId =
+      typeof params?.id === 'string' ? treeUrlSlugToId(params.id) : null
 
     if (!treeId || Array.isArray(treeId)) return { notFound: true }
 

--- a/pages/trees/index.tsx
+++ b/pages/trees/index.tsx
@@ -1,5 +1,6 @@
 import { MapLayout } from '@layouts/MapLayout'
 import { mapRawQueryToState } from '@lib/utils/queryUtil'
+import { treeIdToUrlSlug } from '@lib/utils/urlUtil'
 import { GetServerSideProps, NextPage } from 'next'
 import router from 'next/router'
 import { ReactElement, ReactNode } from 'react'
@@ -33,7 +34,10 @@ MapPage.getLayout = function getLayout(page, props) {
         longitude={props.query?.longitude || undefined}
         zoom={props.query?.zoom || undefined}
         onTreeSelect={(treeId) => {
-          void router.push({ pathname: '/trees/[id]', query: { id: treeId } })
+          void router.push({
+            pathname: '/trees/[id]',
+            query: { id: treeIdToUrlSlug(treeId) },
+          })
         }}
         isMinimized={false}
       />

--- a/src/lib/utils/urlUtil/index.ts
+++ b/src/lib/utils/urlUtil/index.ts
@@ -1,37 +1,7 @@
-import { NextApiRequest } from 'next'
+const DOT_REPLACE_CHAR = '---'
 
-type AbsoluteUrlType = {
-  protocol: string
-  host: string
-  origin: string
-}
-export function absoluteUrl(
-  req: NextApiRequest,
-  localhostAddress = 'localhost:3000'
-): AbsoluteUrlType {
-  let host =
-    (req?.headers ? req.headers.host : window.location.host) || localhostAddress
-  let protocol = /^localhost(:\d+)?$/.test(host) ? 'http:' : 'https:'
+export const treeIdToUrlSlug = (treeId: string): string =>
+  treeId.replaceAll('.', DOT_REPLACE_CHAR)
 
-  if (
-    req &&
-    req.headers['x-forwarded-host'] &&
-    typeof req.headers['x-forwarded-host'] === 'string'
-  ) {
-    host = req.headers['x-forwarded-host']
-  }
-
-  if (
-    req &&
-    req.headers['x-forwarded-proto'] &&
-    typeof req.headers['x-forwarded-proto'] === 'string'
-  ) {
-    protocol = `${req.headers['x-forwarded-proto']}:`
-  }
-
-  return {
-    protocol,
-    host,
-    origin: `${protocol}//${host}`,
-  }
-}
+export const treeUrlSlugToId = (urlSlug: string): string =>
+  urlSlug.replaceAll(DOT_REPLACE_CHAR, '.')


### PR DESCRIPTION
This PR replaces the dot in the URL with a triple --- and replaces the dot back on load. This prevents the 400 when reloading.