### PR TITLE
fix(QTREES-381): Layout shifts in Feedback images

### DIFF
--- a/pages/trees/[id].tsx
+++ b/pages/trees/[id].tsx
@@ -246,7 +246,7 @@ const TreePage: TreePageWithLayout = ({ treeData, csrfToken }) => {
           />
           <div
             className={classNames(
-              'fixed w-screen top-0 z-20 border-gray-300 pointer-events-none',
+              'fixed w-screen top-0 z-50 border-gray-300 pointer-events-none',
               'transition-all',
               hasScrolledPastThreshold
                 ? ' opacity-1 shadow-lg border-b'

--- a/src/components/FeedbackReportForm/FeedbackReportForm.tsx
+++ b/src/components/FeedbackReportForm/FeedbackReportForm.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@components/Button'
 import { Check } from '@components/Icons'
+import { Transition } from '@headlessui/react'
 import { useImageLoadsSuccessfully } from '@lib/hooks/useLoadImage'
 import classNames from 'classnames'
 import useTranslation from 'next-translate/useTranslation'
@@ -29,7 +30,7 @@ export const FeedbackReportForm: FC<FeedbackReportFormPropType> = ({
     <div
       className={classNames(
         'grid p-6 gap-x-6 gap-y-2 border-b border-gray-200',
-        showImg && 'pr-0 grid-cols-[8fr,5fr]'
+        'pr-0 grid-cols-[8fr,5fr]'
       )}
     >
       <div>
@@ -39,7 +40,7 @@ export const FeedbackReportForm: FC<FeedbackReportFormPropType> = ({
           <div
             className={classNames(
               'grid grid-cols-[1fr,24px] gap-x-6',
-              showImg && 'col-span-2 mr-6',
+              'col-span-2 mr-6',
               'mt-4'
             )}
           >
@@ -53,22 +54,32 @@ export const FeedbackReportForm: FC<FeedbackReportFormPropType> = ({
           </div>
         )}
         {!alreadyReported && (
-          <Button
-            onClick={onButtonClick}
-            className={classNames(showImg && 'col-span-2 mr-6 ', 'mt-4')}
-            primary
-          >
+          <Button onClick={onButtonClick} className="col-span-2 mt-6" primary>
             {t('feedback.reportButton', { title })}
           </Button>
         )}
       </div>
-      {showImg && (
-        <img
-          src={imageUrl}
-          alt={t('feedback.imageAlt', { title })}
-          className=" object-cover h-full rounded-l-md"
-        />
-      )}
+      <div
+        className={classNames(
+          'w-full bg-gray-100 aspect-video rounded-l-md',
+          !showImg && imageUrl && 'animate-pulse'
+        )}
+      >
+        <Transition
+          show={!!showImg}
+          enter="transition-opacity duration-500"
+          enterFrom="opacity-0  delay-1000"
+          enterTo="opacity-100"
+          leave="transition-opacity duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div
+            className="w-full aspect-video rounded-l-md bg-cover bg-center"
+            style={{ backgroundImage: `url("${imageUrl || ''}")` }}
+          />
+        </Transition>
+      </div>
     </div>
   )
 }

--- a/src/components/FeedbackReportForm/FeedbackReportForm.tsx
+++ b/src/components/FeedbackReportForm/FeedbackReportForm.tsx
@@ -61,7 +61,7 @@ export const FeedbackReportForm: FC<FeedbackReportFormPropType> = ({
       </div>
       <div
         className={classNames(
-          'w-full bg-gray-100 aspect-video rounded-l-md',
+          'w-full bg-gray-100 h-full rounded-l-md relative max-h-48',
           !showImg && imageUrl && 'animate-pulse'
         )}
       >
@@ -75,7 +75,7 @@ export const FeedbackReportForm: FC<FeedbackReportFormPropType> = ({
           leaveTo="opacity-0"
         >
           <div
-            className="w-full aspect-video rounded-l-md bg-cover bg-center"
+            className="absolute z-0 inset-0 rounded-l-md bg-cover bg-center"
             style={{ backgroundImage: `url("${imageUrl || ''}")` }}
           />
         </Transition>

--- a/src/components/FeedbackReportModal/FeedbackReportModal.tsx
+++ b/src/components/FeedbackReportModal/FeedbackReportModal.tsx
@@ -70,7 +70,7 @@ export const FeedbackReportModal: FC<FeedbackReportModalPropType> = ({
             >
               <div
                 className={classNames(
-                  'bg-gray-100 w-full h-[120px] rounded-t-md overflow-hidden',
+                  'bg-gray-100 w-full h-[120px] rounded-t overflow-hidden',
                   !showImg && imageUrl && 'animate-pulse'
                 )}
               >
@@ -84,7 +84,7 @@ export const FeedbackReportModal: FC<FeedbackReportModalPropType> = ({
                   leaveTo="opacity-0"
                 >
                   <div
-                    className="w-full h-[120px] rounded-t-md bg-cover bg-center"
+                    className="w-full h-[120px] bg-cover bg-center"
                     style={{ backgroundImage: `url("${imageUrl || ''}")` }}
                   />
                 </Transition>

--- a/src/components/FeedbackReportModal/FeedbackReportModal.tsx
+++ b/src/components/FeedbackReportModal/FeedbackReportModal.tsx
@@ -68,13 +68,27 @@ export const FeedbackReportModal: FC<FeedbackReportModalPropType> = ({
                 'grid gap-x-4 gap-y-2 border-b border-gray-200'
               )}
             >
-              {showImg && (
-                <img
-                  src={imageUrl}
-                  alt={t('feedback.imageAlt', { title })}
-                  className="object-cover w-full h-[120px] rounded-t-md"
-                />
-              )}
+              <div
+                className={classNames(
+                  'bg-gray-100 w-full h-[120px] rounded-t-md overflow-hidden',
+                  !showImg && imageUrl && 'animate-pulse'
+                )}
+              >
+                <Transition
+                  show={!!showImg}
+                  enter="transition-opacity duration-500"
+                  enterFrom="opacity-0  delay-1000"
+                  enterTo="opacity-100"
+                  leave="transition-opacity duration-150"
+                  leaveFrom="opacity-100"
+                  leaveTo="opacity-0"
+                >
+                  <div
+                    className="w-full h-[120px] rounded-t-md bg-cover bg-center"
+                    style={{ backgroundImage: `url("${imageUrl || ''}")` }}
+                  />
+                </Transition>
+              </div>
               <Dialog.Title
                 className={classNames('px-6 pt-4 pb-1 font-semibold text-2xl')}
               >

--- a/src/components/FeedbackRequestsList/index.tsx
+++ b/src/components/FeedbackRequestsList/index.tsx
@@ -23,7 +23,7 @@ export const FeedbackRequestsList: FC<FeedbackRequestsListPropType> = ({
     useState<IssueTypeType | null>(null)
 
   return (
-    <>
+    <div className="relative bg-white z-0">
       <p className="px-8 py-8 font-serif md:text-lg">
         {t('feedback.introduction')}
       </p>
@@ -66,6 +66,6 @@ export const FeedbackRequestsList: FC<FeedbackRequestsListPropType> = ({
           </span>
         </div>
       )}
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
This PR ensures that there is no layout shifts in the images of the feedback from and modals